### PR TITLE
fix CoffeeScriptJsTransformer initialization and add a test

### DIFF
--- a/src/main/java/com/github/lltyk/wro4j/services/CoffeeScriptJsTransformer.java
+++ b/src/main/java/com/github/lltyk/wro4j/services/CoffeeScriptJsTransformer.java
@@ -7,7 +7,11 @@ import java.io.StringWriter;
 import org.apache.tapestry5.ioc.annotations.Inject;
 import org.slf4j.Logger;
 
+import ro.isdc.wro.config.Context;
+import ro.isdc.wro.config.jmx.WroConfiguration;
 import ro.isdc.wro.extensions.processor.js.CoffeeScriptProcessor;
+import ro.isdc.wro.model.group.processor.Injector;
+import ro.isdc.wro.model.group.processor.InjectorBuilder;
 import ro.isdc.wro.model.resource.Resource;
 import ro.isdc.wro.model.resource.ResourceType;
 
@@ -18,17 +22,38 @@ import ro.isdc.wro.model.resource.ResourceType;
 
 public class CoffeeScriptJsTransformer extends AbstractTransformer
 {
+
   @Inject
   private Logger log;
+  
+  private final CoffeeScriptProcessor processor;
 
-  public CoffeeScriptJsTransformer() {
+  private final WroConfiguration configuration;
+  
+
+  public CoffeeScriptJsTransformer(WroConfiguration configuration) {
     super("js", "coffee");
+    this.configuration = configuration;
+    try {
+      Context.set(Context.standaloneContext(), configuration);
+      Injector injector = new InjectorBuilder().build();
+      CoffeeScriptProcessor processor = new CoffeeScriptProcessor();
+      injector.inject(processor);
+      this.processor = processor;
+    } finally {
+      Context.unset();
+    }
   }
 
   @Override
   public String doTransform(String name, String content) throws IOException {
     StringWriter writer = new StringWriter();
-    new CoffeeScriptProcessor().process(Resource.create(name, ResourceType.JS), new StringReader(content), writer);
+    try {
+      Context.set(Context.standaloneContext(), configuration);
+      processor.process(Resource.create(name, ResourceType.JS), new StringReader(content), writer);
+    } finally {
+        Context.unset();
+    }
     return writer.toString();
   }
 }

--- a/src/test/java/com/github/ltyk/wro4j/services/TestCoffeeScriptJsTransformer.java
+++ b/src/test/java/com/github/ltyk/wro4j/services/TestCoffeeScriptJsTransformer.java
@@ -1,0 +1,19 @@
+package com.github.ltyk.wro4j.services;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.github.lltyk.wro4j.services.CoffeeScriptJsTransformer;
+
+
+public class TestCoffeeScriptJsTransformer extends BaseTest {
+  private CoffeeScriptJsTransformer transformer;
+
+
+  @Test
+  public void shouldTransformResourceContent() throws Exception {
+    transformer = registry.autobuild(CoffeeScriptJsTransformer.class);
+    Assert.assertEquals("(function() {\n  var x;\n\n  x = 2;\n\n}).call(this);\n", transformer.doTransform("resourceName", "x=2"));
+  }
+}


### PR DESCRIPTION
Sorry, my previous pull request broke the CoffeeScript transformer due to some changes to the initialization mechanism in wro4j.
